### PR TITLE
Update README container name

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To run the consumer, first, get shell access to the Go container and then execut
 
 ```sh
 # Access the Go container
-docker exec -it rabbitmq_go sh
+docker exec -it grd1_go sh
 
 # Run the consumer command
 go run cli/command.go fibonacci


### PR DESCRIPTION
## Summary
- correct the container name in consumer example

## Testing
- `go test ./...` *(fails: module downloads forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68528e3dd4c88333b7e293222d9e7d76