### PR TITLE
Fix README heading capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Go Rabbitmq Docker
+# Go RabbitMQ Docker
 
 This repository showcases a project using Go (Golang), RabbitMQ, and Docker, built with a layered architecture. It includes a Fibonacci sequence demonstration to illustrate the interaction between an API and a consumer. The API, built using the Gin framework, accepts a number as input, and the consumer processes the calculation.
 


### PR DESCRIPTION
## Summary
- correct the capitalization of "RabbitMQ" in README title

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68528e21764483338fe6903c91a7dc8a