### PR TITLE
Fix startup log output

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,11 +12,11 @@ func main() {
 	routes := config.NewRoutes()
 	routes.SetUpRoutes(app)
 
+	fmt.Println("start.")
+
 	err := app.Run(":8000")
 	if err != nil {
 		return
 	}
-
-	fmt.Println("start.")
 
 }


### PR DESCRIPTION
## Summary
- ensure "start." log appears before server starts

## Testing
- `go test ./...` *(fails: Forbidden download)*

------
https://chatgpt.com/codex/tasks/task_e_68528cf11d9483339228d782e03d9452